### PR TITLE
fix: preserve outline SVGs and brand-colored icons in the picker (#10)

### DIFF
--- a/admin/src/components/IconSelect.tsx
+++ b/admin/src/components/IconSelect.tsx
@@ -11,14 +11,46 @@ import { Field } from '@strapi/design-system';
 
 const ThemeableIcon = styled.span<{ $color: string }>`
   display: contents;
-  & > svg,
+
+  & > svg {
+    color: ${(p) => p.$color};
+  }
+
+  & > svg[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+  }
+
+  & > svg:not([stroke]) {
+    fill: ${(p) => p.$color};
+  }
+
   & > svg *[fill]:not([fill='none']) {
     fill: ${(p) => p.$color};
   }
+
   & > svg *[stroke]:not([stroke='none']) {
     stroke: ${(p) => p.$color};
+    fill: none;
   }
 `;
+
+const hasOwnColors = (svg: string): boolean =>
+  /(?:fill|stroke)\s*=\s*["'](?:#|rgb|hsl|url\(#)/i.test(svg) ||
+  /(?:fill|stroke)\s*:\s*(?:#|rgb|hsl)/i.test(svg);
+
+const IconPreview = ({
+  svg,
+  color,
+  style,
+}: {
+  svg: string;
+  color: string;
+  style?: React.CSSProperties;
+}) => {
+  const icon = <Icon icon={svg} style={style} />;
+  if (hasOwnColors(svg)) return icon;
+  return <ThemeableIcon $color={color}>{icon}</ThemeableIcon>;
+};
 
 type IconSelectProps = {
   label: string;
@@ -140,9 +172,11 @@ const IconSelect = (props: IconSelectProps) => {
                 >
                   {selectedIconData ? (
                     <>
-                      <ThemeableIcon $color={theme.colors?.neutral800 || 'currentColor'}>
-                        <Icon icon={selectedIconData.svg} style={{ height: '24px', display: 'block' }} />
-                      </ThemeableIcon>
+                      <IconPreview
+                        svg={selectedIconData.svg}
+                        color={theme.colors?.neutral800 || 'currentColor'}
+                        style={{ height: '24px', display: 'block' }}
+                      />
                       <Typography variant="pi">{selectedIconData.name}</Typography>
                     </>
                   ) : (
@@ -198,7 +232,9 @@ const IconSelect = (props: IconSelectProps) => {
               <Searchbar
                 name="icon-search"
                 value={searchQuery}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setSearchQuery(e.target.value)
+                }
                 onClear={() => setSearchQuery('')}
                 clearLabel={intl.formatMessage({
                   id: 'icons-field.modal.search.clear',
@@ -236,7 +272,8 @@ const IconSelect = (props: IconSelectProps) => {
                 </Typography>
                 <Box display="flex" marginTop={2} style={{ flexWrap: 'wrap', gap: 6 }}>
                   {group.icons.map((icon) => {
-                    const isSelected = outputFormat === 'name' ? value === icon.name : value === icon.svg;
+                    const isSelected =
+                      outputFormat === 'name' ? value === icon.name : value === icon.svg;
                     return (
                       <Box
                         key={icon.name}
@@ -267,19 +304,23 @@ const IconSelect = (props: IconSelectProps) => {
                           width: '85px',
                         }}
                       >
-                        <ThemeableIcon $color={theme.colors?.neutral800 || 'currentColor'}>
-                          <Icon
-                            icon={icon.svg}
-                            style={{
-                              aspectRatio: '1/1',
-                              height: '100%',
-                              maxWidth: '25px',
-                              width: '100%',
-                            }}
-                          />
-                        </ThemeableIcon>
+                        <IconPreview
+                          svg={icon.svg}
+                          color={theme.colors?.neutral800 || 'currentColor'}
+                          style={{
+                            aspectRatio: '1/1',
+                            height: '100%',
+                            maxWidth: '25px',
+                            width: '100%',
+                          }}
+                        />
                         {attribute?.options?.showIconLabel && (
-                          <Typography variant="pi" fontWeight="bold" textColor="neutral800" style={{ marginTop: 8}}>
+                          <Typography
+                            variant="pi"
+                            fontWeight="bold"
+                            textColor="neutral800"
+                            style={{ marginTop: 8 }}
+                          >
                             {icon.name}
                           </Typography>
                         )}

--- a/dist/_chunks/IconSelect-C-A9r_f0.js
+++ b/dist/_chunks/IconSelect-C-A9r_f0.js
@@ -4,7 +4,7 @@ const jsxRuntime = require("react/jsx-runtime");
 const React = require("react");
 const designSystem = require("@strapi/design-system");
 const admin = require("@strapi/strapi/admin");
-const index = require("./index-CoVMQhd4.js");
+const index = require("./index-BxK51aFm.js");
 const parse = require("html-react-parser");
 const styled = require("styled-components");
 const icons = require("@strapi/icons");
@@ -22,14 +22,38 @@ function Icon({ icon, ...props }) {
 }
 const ThemeableIcon = styled__default.default.span`
   display: contents;
-  & > svg,
+
+  & > svg {
+    color: ${(p) => p.$color};
+  }
+
+  & > svg[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+  }
+
+  & > svg:not([stroke]) {
+    fill: ${(p) => p.$color};
+  }
+
   & > svg *[fill]:not([fill='none']) {
     fill: ${(p) => p.$color};
   }
+
   & > svg *[stroke]:not([stroke='none']) {
     stroke: ${(p) => p.$color};
+    fill: none;
   }
 `;
+const hasOwnColors = (svg) => /(?:fill|stroke)\s*=\s*["'](?:#|rgb|hsl|url\(#)/i.test(svg) || /(?:fill|stroke)\s*:\s*(?:#|rgb|hsl)/i.test(svg);
+const IconPreview = ({
+  svg,
+  color,
+  style
+}) => {
+  const icon = /* @__PURE__ */ jsxRuntime.jsx(Icon, { icon: svg, style });
+  if (hasOwnColors(svg)) return icon;
+  return /* @__PURE__ */ jsxRuntime.jsx(ThemeableIcon, { $color: color, children: icon });
+};
 const IconSelect = (props) => {
   const theme = styled.useTheme();
   const intl = reactIntl.useIntl();
@@ -121,7 +145,14 @@ const IconSelect = (props) => {
                         },
                         children: [
                           selectedIconData ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
-                            /* @__PURE__ */ jsxRuntime.jsx(ThemeableIcon, { $color: theme.colors?.neutral800 || "currentColor", children: /* @__PURE__ */ jsxRuntime.jsx(Icon, { icon: selectedIconData.svg, style: { height: "24px", display: "block" } }) }),
+                            /* @__PURE__ */ jsxRuntime.jsx(
+                              IconPreview,
+                              {
+                                svg: selectedIconData.svg,
+                                color: theme.colors?.neutral800 || "currentColor",
+                                style: { height: "24px", display: "block" }
+                              }
+                            ),
                             /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { variant: "pi", children: selectedIconData.name })
                           ] }) : /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { style: { fontWeight: "400" }, children: placeholder ?? intl.formatMessage({
                             id: "icons-field.select",
@@ -234,10 +265,11 @@ const IconSelect = (props) => {
                         width: "85px"
                       },
                       children: [
-                        /* @__PURE__ */ jsxRuntime.jsx(ThemeableIcon, { $color: theme.colors?.neutral800 || "currentColor", children: /* @__PURE__ */ jsxRuntime.jsx(
-                          Icon,
+                        /* @__PURE__ */ jsxRuntime.jsx(
+                          IconPreview,
                           {
-                            icon: icon.svg,
+                            svg: icon.svg,
+                            color: theme.colors?.neutral800 || "currentColor",
                             style: {
                               aspectRatio: "1/1",
                               height: "100%",
@@ -245,8 +277,17 @@ const IconSelect = (props) => {
                               width: "100%"
                             }
                           }
-                        ) }),
-                        attribute?.options?.showIconLabel && /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { variant: "pi", fontWeight: "bold", textColor: "neutral800", style: { marginTop: 8 }, children: icon.name })
+                        ),
+                        attribute?.options?.showIconLabel && /* @__PURE__ */ jsxRuntime.jsx(
+                          designSystem.Typography,
+                          {
+                            variant: "pi",
+                            fontWeight: "bold",
+                            textColor: "neutral800",
+                            style: { marginTop: 8 },
+                            children: icon.name
+                          }
+                        )
                       ]
                     },
                     icon.name
@@ -266,3 +307,4 @@ const IconSelect = (props) => {
   ] });
 };
 exports.default = IconSelect;
+//# sourceMappingURL=IconSelect-C-A9r_f0.js.map

--- a/dist/_chunks/IconSelect-CKhQ-xwl.mjs
+++ b/dist/_chunks/IconSelect-CKhQ-xwl.mjs
@@ -1,0 +1,313 @@
+import { jsxs, jsx, Fragment } from "react/jsx-runtime";
+import React, { useState, useEffect, useMemo } from "react";
+import { Field, Modal, Box, Button, Typography, Searchbar } from "@strapi/design-system";
+import { useFetchClient } from "@strapi/strapi/admin";
+import { P as PLUGIN_ID } from "./index-C9igKtaA.mjs";
+import parse from "html-react-parser";
+import styled, { useTheme } from "styled-components";
+import { CaretDown, Cross } from "@strapi/icons";
+import { useIntl } from "react-intl";
+function Icon({ icon, ...props }) {
+  const parsedElement = icon && parse(icon.trim());
+  if (parsedElement && React.isValidElement(parsedElement)) {
+    return React.cloneElement(parsedElement, props);
+  }
+  return null;
+}
+const ThemeableIcon = styled.span`
+  display: contents;
+
+  /* Resolve any currentColor usage to the theme color. */
+  & > svg {
+    color: ${(p) => p.$color};
+  }
+
+  /*
+   * Stroke-based icons carry the stroke on the <svg> root (e.g. fill="none"
+   * stroke="currentColor"). Recolor that stroke, but never force a fill on
+   * the root — doing so would override fill="none" and flood the hollow
+   * shapes with color, turning outline icons into solid silhouettes.
+   */
+  & > svg[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+  }
+
+  /*
+   * Fill-based icons have no stroke on the root. Their paths often carry no
+   * fill attribute and rely on the root fill to render, so force it here.
+   */
+  & > svg:not([stroke]) {
+    fill: ${(p) => p.$color};
+  }
+
+  /* Any explicitly-filled shape gets recolored. */
+  & > svg *[fill]:not([fill='none']) {
+    fill: ${(p) => p.$color};
+  }
+
+  /*
+   * Any explicitly-stroked shape gets its stroke recolored and its fill
+   * cleared, so a forced root fill (see above) can't leak in and fill the
+   * interior of an outline path.
+   */
+  & > svg *[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+    fill: none;
+  }
+`;
+const hasOwnColors = (svg) => /(?:fill|stroke)\s*=\s*["'](?:#|rgb|hsl|url\(#)/i.test(svg) || /(?:fill|stroke)\s*:\s*(?:#|rgb|hsl)/i.test(svg);
+const IconPreview = ({
+  svg,
+  color,
+  style
+}) => {
+  const icon = /* @__PURE__ */ jsx(Icon, { icon: svg, style });
+  if (hasOwnColors(svg)) return icon;
+  return /* @__PURE__ */ jsx(ThemeableIcon, { $color: color, children: icon });
+};
+const IconSelect = (props) => {
+  const theme = useTheme();
+  const intl = useIntl();
+  const { label, hint, attribute, disabled, error, name, onChange, placeholder, required, value } = props;
+  const [icons, setIcons] = useState([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const { get } = useFetchClient();
+  const toggleModal = () => setIsModalOpen((prev) => !prev);
+  useEffect(() => {
+    const fetchIcons = async () => {
+      try {
+        let url = `/${PLUGIN_ID}/icons`;
+        if (attribute?.options?.selection) {
+          if (Array.isArray(attribute.options.selection)) {
+            url += `?selection=${encodeURIComponent(attribute.options.selection.join(","))}`;
+          } else {
+            url += `?selection=${encodeURIComponent(attribute.options.selection)}`;
+          }
+        }
+        const { data } = await get(url);
+        setIcons(data || []);
+      } catch (error2) {
+        console.error("Error fetching icons:", error2);
+      }
+    };
+    fetchIcons();
+  }, [attribute?.options?.selection]);
+  const outputFormat = attribute?.options?.outputFormat || "svg";
+  const handleChange = (icon) => {
+    const storedValue = outputFormat === "name" ? icon.name : icon.svg;
+    onChange({ target: { name, value: storedValue, type: attribute.type } });
+  };
+  const allIcons = useMemo(() => icons.flatMap((group) => group.icons), [icons]);
+  const selectedIconData = useMemo(() => {
+    if (!value) return void 0;
+    if (outputFormat === "name") {
+      return allIcons.find((icon) => icon.name === value);
+    }
+    return allIcons.find((icon) => icon.svg === value);
+  }, [value, allIcons, outputFormat]);
+  const filteredIcons = useMemo(() => {
+    if (!searchQuery.trim()) return icons;
+    const query = searchQuery.toLowerCase();
+    return icons.map((group) => ({
+      ...group,
+      icons: group.icons.filter((icon) => icon.name.toLowerCase().includes(query))
+    })).filter((group) => group.icons.length > 0);
+  }, [icons, searchQuery]);
+  const handleUnselectedIcon = (e) => {
+    e.stopPropagation();
+    onChange({ target: { name, value: "", type: attribute.type } });
+  };
+  return /* @__PURE__ */ jsxs(Field.Root, { error, hint, required, children: [
+    /* @__PURE__ */ jsx(Field.Label, { children: label }),
+    /* @__PURE__ */ jsxs(
+      Modal.Root,
+      {
+        labelledBy: "icon-select-modal-title",
+        open: isModalOpen,
+        onOpenChange: setIsModalOpen,
+        children: [
+          /* @__PURE__ */ jsx(Modal.Trigger, { children: /* @__PURE__ */ jsxs(
+            Box,
+            {
+              display: "flex",
+              style: { alignItems: "center", gap: "12px", position: "relative", width: "100%" },
+              children: [
+                /* @__PURE__ */ jsx("div", { style: { position: "relative", flex: 1 }, children: /* @__PURE__ */ jsx(
+                  Button,
+                  {
+                    variant: "tertiary",
+                    disabled,
+                    style: {
+                      gap: "8px",
+                      height: "42px",
+                      width: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between"
+                    },
+                    children: /* @__PURE__ */ jsxs(
+                      "div",
+                      {
+                        style: {
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "8px"
+                        },
+                        children: [
+                          selectedIconData ? /* @__PURE__ */ jsxs(Fragment, { children: [
+                            /* @__PURE__ */ jsx(
+                              IconPreview,
+                              {
+                                svg: selectedIconData.svg,
+                                color: theme.colors?.neutral800 || "currentColor",
+                                style: { height: "24px", display: "block" }
+                              }
+                            ),
+                            /* @__PURE__ */ jsx(Typography, { variant: "pi", children: selectedIconData.name })
+                          ] }) : /* @__PURE__ */ jsx(Typography, { style: { fontWeight: "400" }, children: placeholder ?? intl.formatMessage({
+                            id: "icons-field.select",
+                            defaultMessage: "Select an icon"
+                          }) }),
+                          /* @__PURE__ */ jsx(
+                            CaretDown,
+                            {
+                              color: theme.colors?.neutral500,
+                              style: {
+                                position: "absolute",
+                                right: "16px",
+                                height: "16px",
+                                width: "16px"
+                              }
+                            }
+                          )
+                        ]
+                      }
+                    )
+                  }
+                ) }),
+                selectedIconData && /* @__PURE__ */ jsx(
+                  "button",
+                  {
+                    type: "button",
+                    onClick: handleUnselectedIcon,
+                    style: {
+                      position: "absolute",
+                      right: "44px",
+                      height: "16px",
+                      width: "16px",
+                      cursor: "pointer",
+                      zIndex: 3
+                    },
+                    children: /* @__PURE__ */ jsx(Cross, { color: theme.colors?.neutral500, style: { height: "100%", width: "100%" } })
+                  }
+                )
+              ]
+            }
+          ) }),
+          /* @__PURE__ */ jsxs(Modal.Content, { children: [
+            /* @__PURE__ */ jsx(Modal.Header, { children: /* @__PURE__ */ jsx(Typography, { fontWeight: "bold", textColor: "neutral800", as: "h2", id: "title", children: intl.formatMessage({
+              id: "icons-field.modal.title",
+              defaultMessage: "Select an icon"
+            }) }) }),
+            /* @__PURE__ */ jsxs(Modal.Body, { children: [
+              /* @__PURE__ */ jsx(Box, { marginBottom: 4, children: /* @__PURE__ */ jsx(
+                Searchbar,
+                {
+                  name: "icon-search",
+                  value: searchQuery,
+                  onChange: (e) => setSearchQuery(e.target.value),
+                  onClear: () => setSearchQuery(""),
+                  clearLabel: intl.formatMessage({
+                    id: "icons-field.modal.search.clear",
+                    defaultMessage: "Clear search"
+                  }),
+                  placeholder: intl.formatMessage({
+                    id: "icons-field.modal.search.placeholder",
+                    defaultMessage: "Search icons..."
+                  }),
+                  children: intl.formatMessage({
+                    id: "icons-field.modal.search.placeholder",
+                    defaultMessage: "Search icons..."
+                  })
+                }
+              ) }),
+              filteredIcons.length === 0 && /* @__PURE__ */ jsx(Typography, { textColor: "neutral500", children: intl.formatMessage({
+                id: "icons-field.modal.search.empty",
+                defaultMessage: "No icons found."
+              }) }),
+              filteredIcons.map((group) => /* @__PURE__ */ jsxs(Box, { marginBottom: 6, children: [
+                /* @__PURE__ */ jsx(
+                  Typography,
+                  {
+                    fontWeight: "bold",
+                    textColor: "neutral800",
+                    as: "h3",
+                    id: "title",
+                    marginBottom: 2,
+                    children: group.folder
+                  }
+                ),
+                /* @__PURE__ */ jsx(Box, { display: "flex", marginTop: 2, style: { flexWrap: "wrap", gap: 6 }, children: group.icons.map((icon) => {
+                  const isSelected = outputFormat === "name" ? value === icon.name : value === icon.svg;
+                  return /* @__PURE__ */ jsxs(
+                    Box,
+                    {
+                      as: "button",
+                      type: "button",
+                      "aria-label": icon.name,
+                      onClick: () => {
+                        handleChange(icon);
+                        toggleModal();
+                      },
+                      style: {
+                        alignItems: "center",
+                        aspectRatio: "1/1",
+                        background: isSelected ? theme.colors?.primary100 : theme.colors?.neutral100,
+                        border: isSelected ? `2px solid ${theme.colors?.primary600}` : `1px solid ${theme.colors?.neutral200}`,
+                        borderRadius: "4px",
+                        cursor: "pointer",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "2px",
+                        height: "100%",
+                        justifyContent: "center",
+                        padding: "12px",
+                        width: "85px"
+                      },
+                      children: [
+                        /* @__PURE__ */ jsx(
+                          IconPreview,
+                          {
+                            svg: icon.svg,
+                            color: theme.colors?.neutral800 || "currentColor",
+                            style: {
+                              aspectRatio: "1/1",
+                              height: "100%",
+                              maxWidth: "25px",
+                              width: "100%"
+                            }
+                          }
+                        ),
+                        attribute?.options?.showIconLabel && /* @__PURE__ */ jsx(Typography, { variant: "pi", fontWeight: "bold", textColor: "neutral800", style: { marginTop: 8 }, children: icon.name })
+                      ]
+                    },
+                    icon.name
+                  );
+                }) })
+              ] }, group.folder))
+            ] }),
+            /* @__PURE__ */ jsx(Modal.Footer, { children: /* @__PURE__ */ jsx(Modal.Close, { children: /* @__PURE__ */ jsx(Button, { variant: "tertiary", children: intl.formatMessage({
+              id: "icons-field.modal.close",
+              defaultMessage: "Close window"
+            }) }) }) })
+          ] })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsx(Field.Hint, {})
+  ] });
+};
+export {
+  IconSelect as default
+};

--- a/dist/_chunks/IconSelect-DOtSVQWP.js
+++ b/dist/_chunks/IconSelect-DOtSVQWP.js
@@ -1,0 +1,317 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const jsxRuntime = require("react/jsx-runtime");
+const React = require("react");
+const designSystem = require("@strapi/design-system");
+const admin = require("@strapi/strapi/admin");
+const index = require("./index-zInrl2Dd.js");
+const parse = require("html-react-parser");
+const styled = require("styled-components");
+const icons = require("@strapi/icons");
+const reactIntl = require("react-intl");
+const _interopDefault = (e) => e && e.__esModule ? e : { default: e };
+const React__default = /* @__PURE__ */ _interopDefault(React);
+const parse__default = /* @__PURE__ */ _interopDefault(parse);
+const styled__default = /* @__PURE__ */ _interopDefault(styled);
+function Icon({ icon, ...props }) {
+  const parsedElement = icon && parse__default.default(icon.trim());
+  if (parsedElement && React__default.default.isValidElement(parsedElement)) {
+    return React__default.default.cloneElement(parsedElement, props);
+  }
+  return null;
+}
+const ThemeableIcon = styled__default.default.span`
+  display: contents;
+
+  /* Resolve any currentColor usage to the theme color. */
+  & > svg {
+    color: ${(p) => p.$color};
+  }
+
+  /*
+   * Stroke-based icons carry the stroke on the <svg> root (e.g. fill="none"
+   * stroke="currentColor"). Recolor that stroke, but never force a fill on
+   * the root — doing so would override fill="none" and flood the hollow
+   * shapes with color, turning outline icons into solid silhouettes.
+   */
+  & > svg[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+  }
+
+  /*
+   * Fill-based icons have no stroke on the root. Their paths often carry no
+   * fill attribute and rely on the root fill to render, so force it here.
+   */
+  & > svg:not([stroke]) {
+    fill: ${(p) => p.$color};
+  }
+
+  /* Any explicitly-filled shape gets recolored. */
+  & > svg *[fill]:not([fill='none']) {
+    fill: ${(p) => p.$color};
+  }
+
+  /*
+   * Any explicitly-stroked shape gets its stroke recolored and its fill
+   * cleared, so a forced root fill (see above) can't leak in and fill the
+   * interior of an outline path.
+   */
+  & > svg *[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+    fill: none;
+  }
+`;
+const hasOwnColors = (svg) => /(?:fill|stroke)\s*=\s*["'](?:#|rgb|hsl|url\(#)/i.test(svg) || /(?:fill|stroke)\s*:\s*(?:#|rgb|hsl)/i.test(svg);
+const IconPreview = ({
+  svg,
+  color,
+  style
+}) => {
+  const icon = /* @__PURE__ */ jsxRuntime.jsx(Icon, { icon: svg, style });
+  if (hasOwnColors(svg)) return icon;
+  return /* @__PURE__ */ jsxRuntime.jsx(ThemeableIcon, { $color: color, children: icon });
+};
+const IconSelect = (props) => {
+  const theme = styled.useTheme();
+  const intl = reactIntl.useIntl();
+  const { label, hint, attribute, disabled, error, name, onChange, placeholder, required, value } = props;
+  const [icons$1, setIcons] = React.useState([]);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const { get } = admin.useFetchClient();
+  const toggleModal = () => setIsModalOpen((prev) => !prev);
+  React.useEffect(() => {
+    const fetchIcons = async () => {
+      try {
+        let url = `/${index.PLUGIN_ID}/icons`;
+        if (attribute?.options?.selection) {
+          if (Array.isArray(attribute.options.selection)) {
+            url += `?selection=${encodeURIComponent(attribute.options.selection.join(","))}`;
+          } else {
+            url += `?selection=${encodeURIComponent(attribute.options.selection)}`;
+          }
+        }
+        const { data } = await get(url);
+        setIcons(data || []);
+      } catch (error2) {
+        console.error("Error fetching icons:", error2);
+      }
+    };
+    fetchIcons();
+  }, [attribute?.options?.selection]);
+  const outputFormat = attribute?.options?.outputFormat || "svg";
+  const handleChange = (icon) => {
+    const storedValue = outputFormat === "name" ? icon.name : icon.svg;
+    onChange({ target: { name, value: storedValue, type: attribute.type } });
+  };
+  const allIcons = React.useMemo(() => icons$1.flatMap((group) => group.icons), [icons$1]);
+  const selectedIconData = React.useMemo(() => {
+    if (!value) return void 0;
+    if (outputFormat === "name") {
+      return allIcons.find((icon) => icon.name === value);
+    }
+    return allIcons.find((icon) => icon.svg === value);
+  }, [value, allIcons, outputFormat]);
+  const filteredIcons = React.useMemo(() => {
+    if (!searchQuery.trim()) return icons$1;
+    const query = searchQuery.toLowerCase();
+    return icons$1.map((group) => ({
+      ...group,
+      icons: group.icons.filter((icon) => icon.name.toLowerCase().includes(query))
+    })).filter((group) => group.icons.length > 0);
+  }, [icons$1, searchQuery]);
+  const handleUnselectedIcon = (e) => {
+    e.stopPropagation();
+    onChange({ target: { name, value: "", type: attribute.type } });
+  };
+  return /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Field.Root, { error, hint, required, children: [
+    /* @__PURE__ */ jsxRuntime.jsx(designSystem.Field.Label, { children: label }),
+    /* @__PURE__ */ jsxRuntime.jsxs(
+      designSystem.Modal.Root,
+      {
+        labelledBy: "icon-select-modal-title",
+        open: isModalOpen,
+        onOpenChange: setIsModalOpen,
+        children: [
+          /* @__PURE__ */ jsxRuntime.jsx(designSystem.Modal.Trigger, { children: /* @__PURE__ */ jsxRuntime.jsxs(
+            designSystem.Box,
+            {
+              display: "flex",
+              style: { alignItems: "center", gap: "12px", position: "relative", width: "100%" },
+              children: [
+                /* @__PURE__ */ jsxRuntime.jsx("div", { style: { position: "relative", flex: 1 }, children: /* @__PURE__ */ jsxRuntime.jsx(
+                  designSystem.Button,
+                  {
+                    variant: "tertiary",
+                    disabled,
+                    style: {
+                      gap: "8px",
+                      height: "42px",
+                      width: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between"
+                    },
+                    children: /* @__PURE__ */ jsxRuntime.jsxs(
+                      "div",
+                      {
+                        style: {
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "8px"
+                        },
+                        children: [
+                          selectedIconData ? /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+                            /* @__PURE__ */ jsxRuntime.jsx(
+                              IconPreview,
+                              {
+                                svg: selectedIconData.svg,
+                                color: theme.colors?.neutral800 || "currentColor",
+                                style: { height: "24px", display: "block" }
+                              }
+                            ),
+                            /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { variant: "pi", children: selectedIconData.name })
+                          ] }) : /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { style: { fontWeight: "400" }, children: placeholder ?? intl.formatMessage({
+                            id: "icons-field.select",
+                            defaultMessage: "Select an icon"
+                          }) }),
+                          /* @__PURE__ */ jsxRuntime.jsx(
+                            icons.CaretDown,
+                            {
+                              color: theme.colors?.neutral500,
+                              style: {
+                                position: "absolute",
+                                right: "16px",
+                                height: "16px",
+                                width: "16px"
+                              }
+                            }
+                          )
+                        ]
+                      }
+                    )
+                  }
+                ) }),
+                selectedIconData && /* @__PURE__ */ jsxRuntime.jsx(
+                  "button",
+                  {
+                    type: "button",
+                    onClick: handleUnselectedIcon,
+                    style: {
+                      position: "absolute",
+                      right: "44px",
+                      height: "16px",
+                      width: "16px",
+                      cursor: "pointer",
+                      zIndex: 3
+                    },
+                    children: /* @__PURE__ */ jsxRuntime.jsx(icons.Cross, { color: theme.colors?.neutral500, style: { height: "100%", width: "100%" } })
+                  }
+                )
+              ]
+            }
+          ) }),
+          /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Modal.Content, { children: [
+            /* @__PURE__ */ jsxRuntime.jsx(designSystem.Modal.Header, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { fontWeight: "bold", textColor: "neutral800", as: "h2", id: "title", children: intl.formatMessage({
+              id: "icons-field.modal.title",
+              defaultMessage: "Select an icon"
+            }) }) }),
+            /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Modal.Body, { children: [
+              /* @__PURE__ */ jsxRuntime.jsx(designSystem.Box, { marginBottom: 4, children: /* @__PURE__ */ jsxRuntime.jsx(
+                designSystem.Searchbar,
+                {
+                  name: "icon-search",
+                  value: searchQuery,
+                  onChange: (e) => setSearchQuery(e.target.value),
+                  onClear: () => setSearchQuery(""),
+                  clearLabel: intl.formatMessage({
+                    id: "icons-field.modal.search.clear",
+                    defaultMessage: "Clear search"
+                  }),
+                  placeholder: intl.formatMessage({
+                    id: "icons-field.modal.search.placeholder",
+                    defaultMessage: "Search icons..."
+                  }),
+                  children: intl.formatMessage({
+                    id: "icons-field.modal.search.placeholder",
+                    defaultMessage: "Search icons..."
+                  })
+                }
+              ) }),
+              filteredIcons.length === 0 && /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { textColor: "neutral500", children: intl.formatMessage({
+                id: "icons-field.modal.search.empty",
+                defaultMessage: "No icons found."
+              }) }),
+              filteredIcons.map((group) => /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Box, { marginBottom: 6, children: [
+                /* @__PURE__ */ jsxRuntime.jsx(
+                  designSystem.Typography,
+                  {
+                    fontWeight: "bold",
+                    textColor: "neutral800",
+                    as: "h3",
+                    id: "title",
+                    marginBottom: 2,
+                    children: group.folder
+                  }
+                ),
+                /* @__PURE__ */ jsxRuntime.jsx(designSystem.Box, { display: "flex", marginTop: 2, style: { flexWrap: "wrap", gap: 6 }, children: group.icons.map((icon) => {
+                  const isSelected = outputFormat === "name" ? value === icon.name : value === icon.svg;
+                  return /* @__PURE__ */ jsxRuntime.jsxs(
+                    designSystem.Box,
+                    {
+                      as: "button",
+                      type: "button",
+                      "aria-label": icon.name,
+                      onClick: () => {
+                        handleChange(icon);
+                        toggleModal();
+                      },
+                      style: {
+                        alignItems: "center",
+                        aspectRatio: "1/1",
+                        background: isSelected ? theme.colors?.primary100 : theme.colors?.neutral100,
+                        border: isSelected ? `2px solid ${theme.colors?.primary600}` : `1px solid ${theme.colors?.neutral200}`,
+                        borderRadius: "4px",
+                        cursor: "pointer",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "2px",
+                        height: "100%",
+                        justifyContent: "center",
+                        padding: "12px",
+                        width: "85px"
+                      },
+                      children: [
+                        /* @__PURE__ */ jsxRuntime.jsx(
+                          IconPreview,
+                          {
+                            svg: icon.svg,
+                            color: theme.colors?.neutral800 || "currentColor",
+                            style: {
+                              aspectRatio: "1/1",
+                              height: "100%",
+                              maxWidth: "25px",
+                              width: "100%"
+                            }
+                          }
+                        ),
+                        attribute?.options?.showIconLabel && /* @__PURE__ */ jsxRuntime.jsx(designSystem.Typography, { variant: "pi", fontWeight: "bold", textColor: "neutral800", style: { marginTop: 8 }, children: icon.name })
+                      ]
+                    },
+                    icon.name
+                  );
+                }) })
+              ] }, group.folder))
+            ] }),
+            /* @__PURE__ */ jsxRuntime.jsx(designSystem.Modal.Footer, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Modal.Close, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Button, { variant: "tertiary", children: intl.formatMessage({
+              id: "icons-field.modal.close",
+              defaultMessage: "Close window"
+            }) }) }) })
+          ] })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntime.jsx(designSystem.Field.Hint, {})
+  ] });
+};
+exports.default = IconSelect;

--- a/dist/_chunks/IconSelect-d7-HnBJE.mjs
+++ b/dist/_chunks/IconSelect-d7-HnBJE.mjs
@@ -2,7 +2,7 @@ import { jsxs, jsx, Fragment } from "react/jsx-runtime";
 import React, { useState, useEffect, useMemo } from "react";
 import { Field, Modal, Box, Button, Typography, Searchbar } from "@strapi/design-system";
 import { useFetchClient } from "@strapi/strapi/admin";
-import { P as PLUGIN_ID } from "./index-BjpCODkB.mjs";
+import { P as PLUGIN_ID } from "./index-CGwL1r1A.mjs";
 import parse from "html-react-parser";
 import styled, { useTheme } from "styled-components";
 import { CaretDown, Cross } from "@strapi/icons";
@@ -16,14 +16,38 @@ function Icon({ icon, ...props }) {
 }
 const ThemeableIcon = styled.span`
   display: contents;
-  & > svg,
+
+  & > svg {
+    color: ${(p) => p.$color};
+  }
+
+  & > svg[stroke]:not([stroke='none']) {
+    stroke: ${(p) => p.$color};
+  }
+
+  & > svg:not([stroke]) {
+    fill: ${(p) => p.$color};
+  }
+
   & > svg *[fill]:not([fill='none']) {
     fill: ${(p) => p.$color};
   }
+
   & > svg *[stroke]:not([stroke='none']) {
     stroke: ${(p) => p.$color};
+    fill: none;
   }
 `;
+const hasOwnColors = (svg) => /(?:fill|stroke)\s*=\s*["'](?:#|rgb|hsl|url\(#)/i.test(svg) || /(?:fill|stroke)\s*:\s*(?:#|rgb|hsl)/i.test(svg);
+const IconPreview = ({
+  svg,
+  color,
+  style
+}) => {
+  const icon = /* @__PURE__ */ jsx(Icon, { icon: svg, style });
+  if (hasOwnColors(svg)) return icon;
+  return /* @__PURE__ */ jsx(ThemeableIcon, { $color: color, children: icon });
+};
 const IconSelect = (props) => {
   const theme = useTheme();
   const intl = useIntl();
@@ -115,7 +139,14 @@ const IconSelect = (props) => {
                         },
                         children: [
                           selectedIconData ? /* @__PURE__ */ jsxs(Fragment, { children: [
-                            /* @__PURE__ */ jsx(ThemeableIcon, { $color: theme.colors?.neutral800 || "currentColor", children: /* @__PURE__ */ jsx(Icon, { icon: selectedIconData.svg, style: { height: "24px", display: "block" } }) }),
+                            /* @__PURE__ */ jsx(
+                              IconPreview,
+                              {
+                                svg: selectedIconData.svg,
+                                color: theme.colors?.neutral800 || "currentColor",
+                                style: { height: "24px", display: "block" }
+                              }
+                            ),
                             /* @__PURE__ */ jsx(Typography, { variant: "pi", children: selectedIconData.name })
                           ] }) : /* @__PURE__ */ jsx(Typography, { style: { fontWeight: "400" }, children: placeholder ?? intl.formatMessage({
                             id: "icons-field.select",
@@ -228,10 +259,11 @@ const IconSelect = (props) => {
                         width: "85px"
                       },
                       children: [
-                        /* @__PURE__ */ jsx(ThemeableIcon, { $color: theme.colors?.neutral800 || "currentColor", children: /* @__PURE__ */ jsx(
-                          Icon,
+                        /* @__PURE__ */ jsx(
+                          IconPreview,
                           {
-                            icon: icon.svg,
+                            svg: icon.svg,
+                            color: theme.colors?.neutral800 || "currentColor",
                             style: {
                               aspectRatio: "1/1",
                               height: "100%",
@@ -239,8 +271,17 @@ const IconSelect = (props) => {
                               width: "100%"
                             }
                           }
-                        ) }),
-                        attribute?.options?.showIconLabel && /* @__PURE__ */ jsx(Typography, { variant: "pi", fontWeight: "bold", textColor: "neutral800", style: { marginTop: 8 }, children: icon.name })
+                        ),
+                        attribute?.options?.showIconLabel && /* @__PURE__ */ jsx(
+                          Typography,
+                          {
+                            variant: "pi",
+                            fontWeight: "bold",
+                            textColor: "neutral800",
+                            style: { marginTop: 8 },
+                            children: icon.name
+                          }
+                        )
                       ]
                     },
                     icon.name
@@ -262,3 +303,4 @@ const IconSelect = (props) => {
 export {
   IconSelect as default
 };
+//# sourceMappingURL=IconSelect-d7-HnBJE.mjs.map

--- a/dist/_chunks/en-CyOHZXDV.mjs
+++ b/dist/_chunks/en-CyOHZXDV.mjs
@@ -24,3 +24,4 @@ const en = {
 export {
   en as default
 };
+//# sourceMappingURL=en-CyOHZXDV.mjs.map

--- a/dist/_chunks/en-v5566hIn.js
+++ b/dist/_chunks/en-v5566hIn.js
@@ -24,3 +24,4 @@ const en = {
   "icons-field.options.advanced.outputFormat.name": "Icon name"
 };
 exports.default = en;
+//# sourceMappingURL=en-v5566hIn.js.map

--- a/dist/_chunks/fr-Bi2USSJP.mjs
+++ b/dist/_chunks/fr-Bi2USSJP.mjs
@@ -24,3 +24,4 @@ const fr = {
 export {
   fr as default
 };
+//# sourceMappingURL=fr-Bi2USSJP.mjs.map

--- a/dist/_chunks/fr-Cda7PegE.js
+++ b/dist/_chunks/fr-Cda7PegE.js
@@ -24,3 +24,4 @@ const fr = {
   "icons-field.options.advanced.outputFormat.name": "Nom de l'icône"
 };
 exports.default = fr;
+//# sourceMappingURL=fr-Cda7PegE.js.map

--- a/dist/_chunks/index-BxK51aFm.js
+++ b/dist/_chunks/index-BxK51aFm.js
@@ -57,7 +57,7 @@ const index = {
         defaultMessage: "Select any icon from your own config"
       },
       components: {
-        Input: async () => Promise.resolve().then(() => require("./IconSelect-C3tI7nD-.js"))
+        Input: async () => Promise.resolve().then(() => require("./IconSelect-C-A9r_f0.js"))
       },
       options: {
         base: [
@@ -171,3 +171,4 @@ const index = {
 };
 exports.PLUGIN_ID = PLUGIN_ID;
 exports.index = index;
+//# sourceMappingURL=index-BxK51aFm.js.map

--- a/dist/_chunks/index-C9igKtaA.mjs
+++ b/dist/_chunks/index-C9igKtaA.mjs
@@ -54,7 +54,7 @@ const index = {
         defaultMessage: "Select any icon from your own config"
       },
       components: {
-        Input: async () => import("./IconSelect-Dj-n2cVo.mjs")
+        Input: async () => import("./IconSelect-CKhQ-xwl.mjs")
       },
       options: {
         base: [

--- a/dist/_chunks/index-CGwL1r1A.mjs
+++ b/dist/_chunks/index-CGwL1r1A.mjs
@@ -1,0 +1,173 @@
+import { useRef, useEffect } from "react";
+import { jsx } from "react/jsx-runtime";
+import { Flex } from "@strapi/design-system";
+import styled from "styled-components";
+import { Rocket } from "@strapi/icons";
+const __variableDynamicImportRuntimeHelper = (glob, path, segs) => {
+  const v = glob[path];
+  if (v) {
+    return typeof v === "function" ? v() : Promise.resolve(v);
+  }
+  return new Promise((_, reject) => {
+    (typeof queueMicrotask === "function" ? queueMicrotask : setTimeout)(
+      reject.bind(
+        null,
+        new Error(
+          "Unknown variable dynamic import: " + path + (path.split("/").length !== segs ? ". Note that variables only represent file names one level deep." : "")
+        )
+      )
+    );
+  });
+};
+const PLUGIN_ID = "icons-field";
+const Initializer = ({ setPlugin }) => {
+  const ref = useRef(setPlugin);
+  useEffect(() => {
+    ref.current(PLUGIN_ID);
+  }, []);
+  return null;
+};
+const IconBox = styled(Flex)`
+  background-color: #ddfaf2;
+  border: 1px solid #87cec5;
+
+  svg > path {
+    fill: #19a796;
+  }
+`;
+const PluginIcon = () => {
+  return /* @__PURE__ */ jsx(IconBox, { justifyContent: "center", alignItems: "center", width: 7, height: 6, hasRadius: true, "aria-hidden": true, children: /* @__PURE__ */ jsx(Rocket, {}) });
+};
+const index = {
+  register(app) {
+    app.customFields.register({
+      name: "icon",
+      pluginId: "icons-field",
+      type: "text",
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${PLUGIN_ID}.label`,
+        defaultMessage: "Icon Selector"
+      },
+      intlDescription: {
+        id: `${PLUGIN_ID}.description`,
+        defaultMessage: "Select any icon from your own config"
+      },
+      components: {
+        Input: async () => import("./IconSelect-d7-HnBJE.mjs")
+      },
+      options: {
+        base: [
+          {
+            name: "options.selection",
+            type: "text",
+            intlLabel: {
+              id: `${PLUGIN_ID}.options.base.selection`,
+              defaultMessage: "Choose a specific icons folder"
+            },
+            description: {
+              id: `${PLUGIN_ID}.options.base.selection.description`,
+              defaultMessage: "Leave empty to select all icones library"
+            },
+            placeholder: {
+              id: `${PLUGIN_ID}.options.base.selection.placeholder`,
+              defaultMessage: "One folder name per line"
+            }
+          }
+        ],
+        advanced: [
+          {
+            sectionTitle: {
+              id: "global.settings",
+              defaultMessage: "Settings"
+            },
+            items: [
+              {
+                name: "required",
+                type: "checkbox",
+                intlLabel: {
+                  id: `${PLUGIN_ID}.options.advanced.requiredField`,
+                  defaultMessage: "Required field"
+                },
+                description: {
+                  id: `${PLUGIN_ID}.options.advanced.requiredField.description`,
+                  defaultMessage: "You won't be able to create an entry if this field is empty"
+                }
+              },
+              {
+                name: "options.showIconLabel",
+                type: "checkbox",
+                intlLabel: {
+                  id: `${PLUGIN_ID}.options.advanced.showIconLabel`,
+                  defaultMessage: "Show icon label"
+                },
+                description: {
+                  id: `${PLUGIN_ID}.options.advanced.showIconLabel.description`,
+                  defaultMessage: "Show the icon label in the selected icon"
+                }
+              },
+              {
+                name: "options.outputFormat",
+                type: "select",
+                defaultValue: "svg",
+                intlLabel: {
+                  id: `${PLUGIN_ID}.options.advanced.outputFormat`,
+                  defaultMessage: "API output format"
+                },
+                description: {
+                  id: `${PLUGIN_ID}.options.advanced.outputFormat.description`,
+                  defaultMessage: "Choose what value is stored: the full SVG code or just the icon name (useful for SVG sprites)"
+                },
+                options: [
+                  {
+                    key: "svg",
+                    value: "svg",
+                    metadatas: {
+                      intlLabel: {
+                        id: `${PLUGIN_ID}.options.advanced.outputFormat.svg`,
+                        defaultMessage: "SVG code (HTML)"
+                      }
+                    }
+                  },
+                  {
+                    key: "name",
+                    value: "name",
+                    metadatas: {
+                      intlLabel: {
+                        id: `${PLUGIN_ID}.options.advanced.outputFormat.name`,
+                        defaultMessage: "Icon name"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+    app.registerPlugin({
+      id: PLUGIN_ID,
+      initializer: Initializer,
+      isReady: false,
+      name: PLUGIN_ID
+    });
+  },
+  async registerTrads({ locales }) {
+    return Promise.all(
+      locales.map(async (locale) => {
+        try {
+          const { default: data } = await __variableDynamicImportRuntimeHelper(/* @__PURE__ */ Object.assign({ "./translations/en.json": () => import("./en-CyOHZXDV.mjs"), "./translations/fr.json": () => import("./fr-Bi2USSJP.mjs") }), `./translations/${locale}.json`, 3);
+          return { data, locale };
+        } catch {
+          return { data: {}, locale };
+        }
+      })
+    );
+  }
+};
+export {
+  PLUGIN_ID as P,
+  index as i
+};
+//# sourceMappingURL=index-CGwL1r1A.mjs.map

--- a/dist/_chunks/index-zInrl2Dd.js
+++ b/dist/_chunks/index-zInrl2Dd.js
@@ -1,0 +1,173 @@
+"use strict";
+const React = require("react");
+const jsxRuntime = require("react/jsx-runtime");
+const designSystem = require("@strapi/design-system");
+const styled = require("styled-components");
+const icons = require("@strapi/icons");
+const _interopDefault = (e) => e && e.__esModule ? e : { default: e };
+const styled__default = /* @__PURE__ */ _interopDefault(styled);
+const __variableDynamicImportRuntimeHelper = (glob, path, segs) => {
+  const v = glob[path];
+  if (v) {
+    return typeof v === "function" ? v() : Promise.resolve(v);
+  }
+  return new Promise((_, reject) => {
+    (typeof queueMicrotask === "function" ? queueMicrotask : setTimeout)(
+      reject.bind(
+        null,
+        new Error(
+          "Unknown variable dynamic import: " + path + (path.split("/").length !== segs ? ". Note that variables only represent file names one level deep." : "")
+        )
+      )
+    );
+  });
+};
+const PLUGIN_ID = "icons-field";
+const Initializer = ({ setPlugin }) => {
+  const ref = React.useRef(setPlugin);
+  React.useEffect(() => {
+    ref.current(PLUGIN_ID);
+  }, []);
+  return null;
+};
+const IconBox = styled__default.default(designSystem.Flex)`
+  background-color: #ddfaf2;
+  border: 1px solid #87cec5;
+
+  svg > path {
+    fill: #19a796;
+  }
+`;
+const PluginIcon = () => {
+  return /* @__PURE__ */ jsxRuntime.jsx(IconBox, { justifyContent: "center", alignItems: "center", width: 7, height: 6, hasRadius: true, "aria-hidden": true, children: /* @__PURE__ */ jsxRuntime.jsx(icons.Rocket, {}) });
+};
+const index = {
+  register(app) {
+    app.customFields.register({
+      name: "icon",
+      pluginId: "icons-field",
+      type: "text",
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${PLUGIN_ID}.label`,
+        defaultMessage: "Icon Selector"
+      },
+      intlDescription: {
+        id: `${PLUGIN_ID}.description`,
+        defaultMessage: "Select any icon from your own config"
+      },
+      components: {
+        Input: async () => Promise.resolve().then(() => require("./IconSelect-DOtSVQWP.js"))
+      },
+      options: {
+        base: [
+          {
+            name: "options.selection",
+            type: "text",
+            intlLabel: {
+              id: `${PLUGIN_ID}.options.base.selection`,
+              defaultMessage: "Choose a specific icons folder"
+            },
+            description: {
+              id: `${PLUGIN_ID}.options.base.selection.description`,
+              defaultMessage: "Leave empty to select all icones library"
+            },
+            placeholder: {
+              id: `${PLUGIN_ID}.options.base.selection.placeholder`,
+              defaultMessage: "One folder name per line"
+            }
+          }
+        ],
+        advanced: [
+          {
+            sectionTitle: {
+              id: "global.settings",
+              defaultMessage: "Settings"
+            },
+            items: [
+              {
+                name: "required",
+                type: "checkbox",
+                intlLabel: {
+                  id: `${PLUGIN_ID}.options.advanced.requiredField`,
+                  defaultMessage: "Required field"
+                },
+                description: {
+                  id: `${PLUGIN_ID}.options.advanced.requiredField.description`,
+                  defaultMessage: "You won't be able to create an entry if this field is empty"
+                }
+              },
+              {
+                name: "options.showIconLabel",
+                type: "checkbox",
+                intlLabel: {
+                  id: `${PLUGIN_ID}.options.advanced.showIconLabel`,
+                  defaultMessage: "Show icon label"
+                },
+                description: {
+                  id: `${PLUGIN_ID}.options.advanced.showIconLabel.description`,
+                  defaultMessage: "Show the icon label in the selected icon"
+                }
+              },
+              {
+                name: "options.outputFormat",
+                type: "select",
+                defaultValue: "svg",
+                intlLabel: {
+                  id: `${PLUGIN_ID}.options.advanced.outputFormat`,
+                  defaultMessage: "API output format"
+                },
+                description: {
+                  id: `${PLUGIN_ID}.options.advanced.outputFormat.description`,
+                  defaultMessage: "Choose what value is stored: the full SVG code or just the icon name (useful for SVG sprites)"
+                },
+                options: [
+                  {
+                    key: "svg",
+                    value: "svg",
+                    metadatas: {
+                      intlLabel: {
+                        id: `${PLUGIN_ID}.options.advanced.outputFormat.svg`,
+                        defaultMessage: "SVG code (HTML)"
+                      }
+                    }
+                  },
+                  {
+                    key: "name",
+                    value: "name",
+                    metadatas: {
+                      intlLabel: {
+                        id: `${PLUGIN_ID}.options.advanced.outputFormat.name`,
+                        defaultMessage: "Icon name"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+    app.registerPlugin({
+      id: PLUGIN_ID,
+      initializer: Initializer,
+      isReady: false,
+      name: PLUGIN_ID
+    });
+  },
+  async registerTrads({ locales }) {
+    return Promise.all(
+      locales.map(async (locale) => {
+        try {
+          const { default: data } = await __variableDynamicImportRuntimeHelper(/* @__PURE__ */ Object.assign({ "./translations/en.json": () => Promise.resolve().then(() => require("./en-v5566hIn.js")), "./translations/fr.json": () => Promise.resolve().then(() => require("./fr-Cda7PegE.js")) }), `./translations/${locale}.json`, 3);
+          return { data, locale };
+        } catch {
+          return { data: {}, locale };
+        }
+      })
+    );
+  }
+};
+exports.PLUGIN_ID = PLUGIN_ID;
+exports.index = index;

--- a/dist/admin/index.js
+++ b/dist/admin/index.js
@@ -1,3 +1,4 @@
 "use strict";
-const index = require("../_chunks/index-CoVMQhd4.js");
+const index = require("../_chunks/index-BxK51aFm.js");
 module.exports = index.index;
+//# sourceMappingURL=index.js.map

--- a/dist/admin/index.mjs
+++ b/dist/admin/index.mjs
@@ -1,4 +1,5 @@
-import { i } from "../_chunks/index-BjpCODkB.mjs";
+import { i } from "../_chunks/index-CGwL1r1A.mjs";
 export {
   i as default
 };
+//# sourceMappingURL=index.mjs.map


### PR DESCRIPTION
## Context

Follow-up fix for #10 (reopened). The earlier fix broke two categories of icons in the picker.

## Problems

1. **Outline (stroke-based) icons rendered as solid silhouettes.** `& > svg { fill: $color }` overrode the root `fill="none"`, and because `fill` is inherited in SVG, every hollow path got filled — e.g. `box-propres`, `clock`, `icon-user`.
2. **Brand logos were flattened to one color.** Multi-color logos (Visa, Mastercard, CB, Amex, Alipay, …) had all their fills recolored to the neutral theme color, losing their identity.

## Fix

`ThemeableIcon` now distinguishes stroke-based from fill-based SVG roots:

- roots that carry a `stroke` keep their `fill="none"` (no forced fill);
- fill-based roots (no stroke) still get a fill so bare paths render (e.g. `Email.svg`);
- explicitly stroked shapes reset `fill: none`, so a forced root fill can't leak into an outline's interior;
- `color` is set so any `currentColor` resolves to the theme color.

New `hasOwnColors` helper detects icons that declare their own colors (hex / `rgb()` / gradient) and renders them **untouched** via a new `IconPreview` component — brand logos keep their original appearance, monochrome UI icons still adapt to the theme.

## Verification

- Outline icons (`box-propres`, `clock`, `euros`, `icon-user`) → correct outlines, transparent interiors.
- Filled monochrome icons (`Email`, `facebook`, `instagram`) → visible, themed.
- Brand logos (`Visa`, `Mastercard`, `CB`, `Amex`, `Alipay`) → original colors preserved.
- `tsc -p admin/tsconfig.json --noEmit` passes.

Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)